### PR TITLE
Add autoloads for ssh-known-hosts-mode and ssh-authorized-keys-mode

### DIFF
--- a/ssh-config-mode.el
+++ b/ssh-config-mode.el
@@ -203,6 +203,7 @@
   "Expressions to hilight in `ssh-config-mode'.")
 ;; ssh-config-font-lock-keywords
 
+;;;###autoload
 (defun ssh-known-hosts-mode ()
   "Major mode for fontifiying ssh known_hosts files.
 \\{ssh-known-hosts-mode}"
@@ -222,6 +223,7 @@
 
 ;;;;;
 
+;;;###autoload (autoload 'ssh-authorized-keys-mode "ssh-config-mode" nil t)
 (define-generic-mode ssh-authorized-keys-mode
   '(?\#)
   nil


### PR DESCRIPTION
Add autoloads for `ssh-known-hosts-mode` and `ssh-authorized-keys-mode`. Since they're added to `auto-mode-alist` via `autoload`-ed code, it makes sense to also `autoload` the mode functions themselves. Otherwise, a `void-function` error is signaled if a user visits a known_hosts or authorized_keys file before `ssh-config-mode` has been loaded.