### PR TITLE
Support shift-select-mode in the motion keys

### DIFF
--- a/ssh-config-mode.el
+++ b/ssh-config-mode.el
@@ -83,11 +83,11 @@
 
 (defun ssh-config-host-next ()
   "Skip to the next host entry."
-  (interactive)
+  (interactive "^")
   (search-forward-regexp ssh-config-host-regexp))
 (defun ssh-config-host-prev ()
   "Skip to the previous host entry."
-  (interactive)
+  (interactive "^")
   (search-backward-regexp ssh-config-host-regexp))
 
 ;;


### PR DESCRIPTION
See elisp manual 20.2.2, Code characters for 'interactive'.

Now S-C-up, S-C-down allow you to select the Host entries you move over.  This can be disabled by setting `shift-select-mode' to nil.