### PR TITLE
Added indentation functionality

### DIFF
--- a/ssh-config-mode.el
+++ b/ssh-config-mode.el
@@ -96,6 +96,13 @@
 (defvar ssh-config-host-regexp "^\\s-*Host\\b"
   "Regexp to match the start of a host entry.")
 
+(defcustom ssh-config-mode-indent 8
+  "The width of indentation to use.
+By default it's set to 2 as that is what man page
+ssh_config(5) shows it as."
+  :type 'integer
+  :group 'ssh-config-mode)
+
 (defun ssh-config-host-next ()
   "Skip to the next host entry."
   (interactive "^")
@@ -114,7 +121,7 @@
       (cond
        ((or (bobp) (looking-at (concat start-of-regex "#"))) (indent-line-to 0))
        ((looking-at (concat start-of-regex (regexp-opt (remove "Host" ssh-config-keywords))))
-	(indent-line-to 2))))))
+	(indent-line-to ssh-config-mode-indent))))))
 
 ;;
 (defvar ssh-config-mode-map

--- a/ssh-config-mode.el
+++ b/ssh-config-mode.el
@@ -105,12 +105,24 @@
   (interactive "^")
   (search-backward-regexp ssh-config-host-regexp))
 
+(defun ssh-config-indent-line ()
+  "Indent lines in the SSH config file"
+  (interactive)
+  (let ((start-of-regex "^\\([ \t]\\)?.*"))
+    (save-excursion
+      (beginning-of-line)
+      (cond
+       ((or (bobp) (looking-at (concat start-of-regex "#"))) (indent-line-to 0))
+       ((looking-at (concat start-of-regex (regexp-opt (remove "Host" ssh-config-keywords))))
+	(indent-line-to 2))))))
+
 ;;
 (defvar ssh-config-mode-map
   (let ((map (make-sparse-keymap)))
     ;; Ctrl bindings
     (define-key map [C-up]   'ssh-config-host-prev)
     (define-key map [C-down] 'ssh-config-host-next)
+    (define-key map [?\t] 'ssh-config-indent-line)
     map)
   "The local keymap for `ssh-config-mode'.")
 


### PR DESCRIPTION
Hello @jhgorrell 

This is more of a conversation starter, rather than a finished PR.

I noticed that indentation was missing from the mode, on a few occasions, 
so figured I'd add it and see what you think. 

Here it goes:

A good SSH config file is properly indented. While that was possible
to do manually, it's better if Emacs just does it for you. So I've
added a very crude implementation of the indentation. The premise is
this:

- if it's a comment or beginning of buffer, start at column 0
- if it's a line starting with 'Host', also indent to column 0
- all other SSH keywords should indent to 2 spaces

Now, I know that I've hardcoded '2 spaces', which should be
configurable, but for me it's what I'd like. And this is meant to be
just a demo of what it could be like. So before I go on a safari where
I try to add feature that are shiny and nice, I thought of throwing
this up and seeing if it's something you might be interested in.

Is this something that you might be interested in to add to your mode?

Thank you for your time