### PR TITLE
Add macOS keyword

### DIFF
--- a/ssh-config-keywords.txt
+++ b/ssh-config-keywords.txt
@@ -99,6 +99,7 @@ tisauthentication
 tunnel
 tunneldevice
 updatehostkeys
+usekeychain
 user
 userknownhostsfile
 verifyhostkeydns


### PR DESCRIPTION
Add an extra keyword for macOS' ssh

https://github.com/apple-oss-distributions/OpenSSH/blob/cde919fd5d3fc8bb2ca9709a9ece99737523ec22/openssh/ssh_config.5#L1667